### PR TITLE
Add parameter `inverseRelationshipName` to customize the OrderedRelationship's inverse property

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The name of the class containing the declaration (`Item` in the example above). 
 ### itemClassName
 The name of the class that the items are. If `nil`, will be inferred by name of the declared array contents without the prefix. In the example above with the array contents being of type `OrderedSubItem`, the type should be `SubItem`.
 
+### inverseRelationshipName
+The name of the property in `itemClassName` to use for the inverse relationship. Defaults to `superitem`, and in the example above would be `SubItem.superitem`. You are always required to create a property for the inverse relationship, and this argument allows you to tell the macro what it is.
+
 ### arrayVariableName
 The variable name of the resulting array. If `nil`, will be inferred by the name of the declared variable without the prefix. In the example above with the variable name being called `orderedSubItems`, the resulting array will be called `subItems`.
 

--- a/Sources/OrderedRelationship/OrderedRelationship.swift
+++ b/Sources/OrderedRelationship/OrderedRelationship.swift
@@ -1,6 +1,6 @@
 import SwiftData
 
-/// A macro that makes a relationship an ordered relationship. It has to be appliced to a variable declaration that is an optional array containing a type name that is not yet defined. For example:
+/// A macro that makes a relationship an ordered relationship. It has to be applied to a variable declaration that is an optional array containing a type name that is not yet defined. For example:
 ///
 ///     @OrderedRelationship var rawSubItems: [OrderedSubItem]? = nil
 ///

--- a/Sources/OrderedRelationship/OrderedRelationship.swift
+++ b/Sources/OrderedRelationship/OrderedRelationship.swift
@@ -9,12 +9,14 @@ import SwiftData
 /// - Parameters:
 ///   - containingClassName: The name of the class containing the declaration. If `nil`, will be inferred by filename.
 ///   - itemClassName: The name of the class that the items are. If `nil`, will be inferred by name of the declared array contents without the prefix. In the example above with the array contents being of type `OrderedSubItem`, the type should be `SubItem`.
+///   - inverseRelationshipName: The name of the property in `itemClassName` to use for the inverse relationship. Defaults to `superitem`, and in the example above would be `SubItem.superitem`
 ///   - arrayVariableName: The variable name of the resulting array. If `nil`, will be inferred by the name of the declared variable without the prefix. In the example above with the variable name being called `rawSubItems`, the resulting array will be called `subItems`.
 ///   - deleteRule: The delete rule to apply to the items. The default value is `.cascade`.
 @attached(peer, names: overloaded, arbitrary)
 public macro OrderedRelationship(
     containingClassName: String? = nil,
     itemClassName: String? = nil,
+    inverseRelationshipName: String? = nil,
     arrayVariableName: String? = nil,
     deleteRule: Schema.Relationship.DeleteRule = .cascade
 ) = #externalMacro(module: "OrderedRelationshipMacros", type: "OrderedRelationshipMacro")

--- a/Sources/OrderedRelationshipMacros/OrderedRelationshipMacro.swift
+++ b/Sources/OrderedRelationshipMacros/OrderedRelationshipMacro.swift
@@ -18,8 +18,8 @@ extension OrderedRelationshipMacro: PeerMacro {
     public static func expansion(of node: SwiftSyntax.AttributeSyntax, providingPeersOf declaration: some SwiftSyntax.DeclSyntaxProtocol, in context: some SwiftSyntaxMacros.MacroExpansionContext) throws -> [SwiftSyntax.DeclSyntax] {
         
         let argumentList = node.arguments?.as(LabeledExprListSyntax.self) ?? []
-        let containingModelName: String? = argumentList.first?.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue
-        
+        let containingModelName = argumentList.argumentValue(labeled: "containingClassName")
+
         // Find variable and its name
         guard
             let varDecl = declaration.as(VariableDeclSyntax.self),

--- a/Sources/OrderedRelationshipMacros/OrderedRelationshipMacro.swift
+++ b/Sources/OrderedRelationshipMacros/OrderedRelationshipMacro.swift
@@ -55,7 +55,15 @@ extension OrderedRelationshipMacro: PeerMacro {
         } else {
             throw OrderedRelationshipError.message("Could not infer the items class name, please provide one using the `itemClassName` argument.")
         }
-        
+
+        // Find inverseRelationshipName
+        let inverseRelationshipName: String
+        if let name = argumentList.first(labeled: "inverseRelationshipName")?.expression.as(StringLiteralExprSyntax.self)?.representedLiteralValue {
+            inverseRelationshipName = name
+        } else {
+            inverseRelationshipName = "superitem"
+        }
+
         // Make sure there is no accessorBlock
         guard binding.accessorBlock == nil else {
             throw OrderedRelationshipError.message("@OrderedRelationship does not support get and set blocks")
@@ -75,7 +83,7 @@ extension OrderedRelationshipMacro: PeerMacro {
             @Model
             class \(orderedClass) {
                 var order: Int = 0
-                @Relationship(deleteRule: \(raw: deleteRule), inverse: \\\(raw: itemClassName).superitem) var item: \(raw: itemClassName)? = nil
+                @Relationship(deleteRule: \(raw: deleteRule), inverse: \\\(raw: itemClassName).\(raw: inverseRelationshipName)) var item: \(raw: itemClassName)? = nil
                 @Relationship(deleteRule: .nullify, inverse: \\\(raw: className).\(raw: orderedVariableName)) var container: \(raw: className)? = nil
                 
                 init(order: Int, item: \(raw: itemClassName), container: \(raw: className)) {

--- a/Tests/OrderedRelationshipTests/OrderedRelationshipTests.swift
+++ b/Tests/OrderedRelationshipTests/OrderedRelationshipTests.swift
@@ -296,10 +296,12 @@ final class OrderedRelationshipTests: XCTestCase {
 
     func testOmittedContainingClassName() throws {
 #if canImport(OrderedRelationshipMacros)
+        let fileName = "MyItem"
+
         assertMacroExpansion(
             """
             @Model
-            final class OrderedRelationshipTests {
+            final class \(fileName) {
                 @OrderedRelationship(inverseRelationshipName: "parentItem")
                 var rawSubItems: [OrderedSubItem]? = []
 
@@ -308,23 +310,23 @@ final class OrderedRelationshipTests: XCTestCase {
 
             @Model
             class SubItem {
-                var parentItem: OrderedRelationshipTests.OrderedSubItem? = nil
+                var parentItem: \(fileName).OrderedSubItem? = nil
 
                 init() {}
             }
             """,
             expandedSource: """
             @Model
-            final class OrderedRelationshipTests {
+            final class \(fileName) {
                 var rawSubItems: [OrderedSubItem]? = []
 
                 @Model
                 class OrderedSubItem {
                     var order: Int = 0
                     @Relationship(deleteRule: .cascade, inverse: \\SubItem.parentItem) var item: SubItem? = nil
-                    @Relationship(deleteRule: .nullify, inverse: \\OrderedRelationshipTests.rawSubItems) var container: Item? = nil
+                    @Relationship(deleteRule: .nullify, inverse: \\\(fileName).rawSubItems) var container: \(fileName)? = nil
 
-                    init(order: Int, item: SubItem, container: Item) {
+                    init(order: Int, item: SubItem, container: \(fileName)) {
                         self.order = order
 
                         guard let context = container.modelContext else {
@@ -423,12 +425,13 @@ final class OrderedRelationshipTests: XCTestCase {
 
             @Model
             class SubItem {
-                var parentItem: OrderedRelationshipTests.OrderedSubItem? = nil
+                var parentItem: \(fileName).OrderedSubItem? = nil
 
                 init() {}
             }
             """,
-            macros: testMacros
+            macros: testMacros,
+            testFileName: fileName + ".swift"
         )
 #else
         throw XCTSkip("macros are only supported when running tests for the host platform")

--- a/Tests/OrderedRelationshipTests/OrderedRelationshipTests.swift
+++ b/Tests/OrderedRelationshipTests/OrderedRelationshipTests.swift
@@ -293,4 +293,145 @@ final class OrderedRelationshipTests: XCTestCase {
         throw XCTSkip("macros are only supported when running tests for the host platform")
 #endif
     }
+
+    func testOmittedContainingClassName() throws {
+#if canImport(OrderedRelationshipMacros)
+        assertMacroExpansion(
+            """
+            @Model
+            final class OrderedRelationshipTests {
+                @OrderedRelationship(inverseRelationshipName: "parentItem")
+                var rawSubItems: [OrderedSubItem]? = []
+
+                init() {}
+            }
+
+            @Model
+            class SubItem {
+                var parentItem: OrderedRelationshipTests.OrderedSubItem? = nil
+
+                init() {}
+            }
+            """,
+            expandedSource: """
+            @Model
+            final class OrderedRelationshipTests {
+                var rawSubItems: [OrderedSubItem]? = []
+
+                @Model
+                class OrderedSubItem {
+                    var order: Int = 0
+                    @Relationship(deleteRule: .cascade, inverse: \\SubItem.parentItem) var item: SubItem? = nil
+                    @Relationship(deleteRule: .nullify, inverse: \\OrderedRelationshipTests.rawSubItems) var container: Item? = nil
+
+                    init(order: Int, item: SubItem, container: Item) {
+                        self.order = order
+
+                        guard let context = container.modelContext else {
+                            fatalError("Given container for OrderedSubItem has no modelContext.")
+                        }
+                        context.insert(self)
+
+                        if item.modelContext == nil {
+                            context.insert(item)
+                        } else if item.modelContext != context {
+                            fatalError("New item has different modelContext than its container.")
+                        }
+
+                        self.item = item
+                        self.container = container
+                    }
+                }
+
+                var subItems: [SubItem] {
+                    get {
+                        (rawSubItems ?? []).sorted(using: SortDescriptor(\\.order)).compactMap(\\.item)
+                    }
+                    set {
+                        guard let modelContext else {
+                            fatalError("\\(self) is not inserted into a ModelContext yet.")
+                        }
+
+                        var oldOrder = (rawSubItems ?? []).sorted(using: SortDescriptor(\\.order))
+                        let newOrder = newValue.map({ newValueItem in
+                            oldOrder.first {
+                                $0.item == newValueItem
+                            } ?? .init(order: 0, item: newValueItem, container: self)
+                        })
+                        let differences = newOrder.difference(from: oldOrder)
+
+                        func completelyRearrangeArray() {
+                            let count = newOrder.count
+                            switch count {
+                                case 0:
+                                    return
+                                case 1:
+                                    newOrder[0].order = 0
+                                    return
+                                default:
+                                    break
+                            }
+
+                            let offset = Int.min / 2
+                            let portion = Int.max / (count - 1)
+
+                            for index in 0 ..< count {
+                                newOrder[index].order = offset + portion * index
+                            }
+                        }
+
+                        for difference in differences {
+                            switch difference {
+                                case .remove(let offset, let element, _):
+                                    if !newOrder.contains(element) {
+                                        modelContext.delete(element)
+                                    }
+                                    oldOrder.remove(at: offset)
+                                case .insert(let offset, let element, _):
+                                    if oldOrder.isEmpty {
+                                        element.order = 0
+                                        oldOrder.insert(element, at: offset)
+                                        continue
+                                    }
+
+                                    var from = Int.min / 2
+                                    var to = Int.max / 2
+
+                                    if offset > 0 {
+                                        from = oldOrder[offset - 1].order + 1
+                                    }
+                                    if offset < oldOrder.count {
+                                        to = oldOrder[offset].order
+                                    }
+
+                                    guard from < to else {
+                                        completelyRearrangeArray()
+                                        return
+                                    }
+
+                                    let range: Range<Int> = from ..< to
+                                    element.order = range.randomElement()!
+
+                                    oldOrder.insert(element, at: offset)
+                            }
+                        }
+                    }
+                }
+
+                init() {}
+            }
+
+            @Model
+            class SubItem {
+                var parentItem: OrderedRelationshipTests.OrderedSubItem? = nil
+
+                init() {}
+            }
+            """,
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
 }

--- a/Tests/OrderedRelationshipTests/OrderedRelationshipTests.swift
+++ b/Tests/OrderedRelationshipTests/OrderedRelationshipTests.swift
@@ -152,4 +152,145 @@ final class OrderedRelationshipTests: XCTestCase {
         throw XCTSkip("macros are only supported when running tests for the host platform")
         #endif
     }
+
+    func testCustomizedInverseRelationshipNameMacro() throws {
+#if canImport(OrderedRelationshipMacros)
+        assertMacroExpansion(
+            """
+            @Model
+            final class Item {
+                @OrderedRelationship(containingClassName: "Item", inverseRelationshipName: "parentItem")
+                var rawSubItems: [OrderedSubItem]? = []
+
+                init() {}
+            }
+
+            @Model
+            class SubItem {
+                var parentItem: Item.OrderedSubItem? = nil
+
+                init() {}
+            }
+            """,
+            expandedSource: """
+            @Model
+            final class Item {
+                var rawSubItems: [OrderedSubItem]? = []
+
+                @Model
+                class OrderedSubItem {
+                    var order: Int = 0
+                    @Relationship(deleteRule: .cascade, inverse: \\SubItem.parentItem) var item: SubItem? = nil
+                    @Relationship(deleteRule: .nullify, inverse: \\Item.rawSubItems) var container: Item? = nil
+
+                    init(order: Int, item: SubItem, container: Item) {
+                        self.order = order
+
+                        guard let context = container.modelContext else {
+                            fatalError("Given container for OrderedSubItem has no modelContext.")
+                        }
+                        context.insert(self)
+
+                        if item.modelContext == nil {
+                            context.insert(item)
+                        } else if item.modelContext != context {
+                            fatalError("New item has different modelContext than its container.")
+                        }
+
+                        self.item = item
+                        self.container = container
+                    }
+                }
+
+                var subItems: [SubItem] {
+                    get {
+                        (rawSubItems ?? []).sorted(using: SortDescriptor(\\.order)).compactMap(\\.item)
+                    }
+                    set {
+                        guard let modelContext else {
+                            fatalError("\\(self) is not inserted into a ModelContext yet.")
+                        }
+
+                        var oldOrder = (rawSubItems ?? []).sorted(using: SortDescriptor(\\.order))
+                        let newOrder = newValue.map({ newValueItem in
+                            oldOrder.first {
+                                $0.item == newValueItem
+                            } ?? .init(order: 0, item: newValueItem, container: self)
+                        })
+                        let differences = newOrder.difference(from: oldOrder)
+
+                        func completelyRearrangeArray() {
+                            let count = newOrder.count
+                            switch count {
+                                case 0:
+                                    return
+                                case 1:
+                                    newOrder[0].order = 0
+                                    return
+                                default:
+                                    break
+                            }
+
+                            let offset = Int.min / 2
+                            let portion = Int.max / (count - 1)
+
+                            for index in 0 ..< count {
+                                newOrder[index].order = offset + portion * index
+                            }
+                        }
+
+                        for difference in differences {
+                            switch difference {
+                                case .remove(let offset, let element, _):
+                                    if !newOrder.contains(element) {
+                                        modelContext.delete(element)
+                                    }
+                                    oldOrder.remove(at: offset)
+                                case .insert(let offset, let element, _):
+                                    if oldOrder.isEmpty {
+                                        element.order = 0
+                                        oldOrder.insert(element, at: offset)
+                                        continue
+                                    }
+
+                                    var from = Int.min / 2
+                                    var to = Int.max / 2
+
+                                    if offset > 0 {
+                                        from = oldOrder[offset - 1].order + 1
+                                    }
+                                    if offset < oldOrder.count {
+                                        to = oldOrder[offset].order
+                                    }
+
+                                    guard from < to else {
+                                        completelyRearrangeArray()
+                                        return
+                                    }
+
+                                    let range: Range<Int> = from ..< to
+                                    element.order = range.randomElement()!
+
+                                    oldOrder.insert(element, at: offset)
+                            }
+                        }
+                    }
+                }
+
+                init() {}
+            }
+
+            @Model
+            class SubItem {
+                var parentItem: Item.OrderedSubItem? = nil
+
+                init() {}
+            }
+            """,
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
 }


### PR DESCRIPTION
The macro is currently hardcoded to `superitem`. Two main problems: 

- it doesn't allow multiple OrderedRelationship macros to point to the same SubItem model class,
- it doesn't work well if `superitem` doesn't describe the containing class well.

This PR also fixes a bug around `containingClassName`: the current implementation doesn't use the label, it just uses the first argument, even if that argument is one of the other labeled args.

I've added some tests around existing functionality and the new `inverseRelationshipName`